### PR TITLE
Add flag for skip downloads binaries

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -8,6 +8,9 @@ neofs_ir__docker_image: 'nspccdev/neofs-ir:{{ neofs_ir__version }}'
 neofs_ir__locodedb_version: 'v0.2.1'
 neofs_ir__locodedb_url: 'https://github.com/nspcc-dev/neofs-locode-db/releases/download/{{ neofs_ir__locodedb_version }}/locode_db'
 
+# Flag to skip binaries download
+neofs_ir__binaries_download: True
+
 # Instance name to have multiple NeoFS nodes on the same host
 neofs_ir__instance: ''
 
@@ -187,3 +190,4 @@ neofs_ir__ferm__dependent_rules:
     protocol: 'tcp'
     role: 'neofs-ir'
     rule_state: "{{ 'present' if neofs_ir__control_enabled else 'absent' }}"
+

--- a/tasks/binary.yml
+++ b/tasks/binary.yml
@@ -9,4 +9,4 @@
     group: 'root'
     mode: '0755'
   notify: [ 'Restart NeoFS IR' ]
-  when: not (neofs_ir__use_compose | bool)
+  when: neofs_ir__binaries_download | bool

--- a/tasks/cli.yml
+++ b/tasks/cli.yml
@@ -8,3 +8,4 @@
     owner: 'root'
     group: 'root'
     mode: '0755'
+  when: neofs_ir__binaries_download | bool


### PR DESCRIPTION
There are scenarios in CI/CD environments when we already have binaries deployed on the target system and use the role for configuration only. For such cases we need a way to prevent the binaries to be overwritten. Sine the role doesn't have proper support for different installation types (source, download binaries, install packages, etc.), this PR adds a flag that can be replaced in future with a "dummy" install type.